### PR TITLE
Use GitHub actions to build and push the container image

### DIFF
--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -3,7 +3,7 @@ name: ci
 on:
   push:
     branches:
-      - 'main'
+      - 'master'
 
 jobs:
   docker:

--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -25,4 +25,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.GITHUB_REPOSITORY }}/docker-react:latest
+          tags: ${{ env.GITHUB_REPOSITORY }}:latest

--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -25,4 +25,4 @@ jobs:
         with:
           context: .
           push: false
-          tags: ${{ GITHUB_ACTION_REPOSITORY }}/docker-react:latest
+          tags: ${{ GITHUB_REPOSITORY }}/docker-react:latest

--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -1,0 +1,28 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: false
+          tags: ${{env.GITHUB_ACTION_REPOSITORY}}/docker-react:latest

--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -25,4 +25,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.GITHUB_REPOSITORY }}:latest
+          tags: ${{ github.repository }}:latest

--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -24,5 +24,5 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          push: false
+          push: true
           tags: ${{ env.GITHUB_REPOSITORY }}/docker-react:latest

--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -25,4 +25,4 @@ jobs:
         with:
           context: .
           push: false
-          tags: ${{ GITHUB_REPOSITORY }}/docker-react:latest
+          tags: ${{ env.GITHUB_REPOSITORY }}/docker-react:latest

--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -25,4 +25,4 @@ jobs:
         with:
           context: .
           push: false
-          tags: ${{env.GITHUB_ACTION_REPOSITORY}}/docker-react:latest
+          tags: ${{ GITHUB_ACTION_REPOSITORY }}/docker-react:latest


### PR DESCRIPTION
Use [GitHub Actions](https://github.com/features/actions) to build and push a container image using the existing Dockerfile.

--
Prerequisites:

- Create [GitHub secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository) with docker hub username (DOCKERHUB_USERNAME) and [access token](https://docs.docker.com/docker-hub/access-tokens/) (DOCKERHUB_TOKEN)

The GitHub action will try to push to a docker hub registry that matches the name from the GITHUB_REPOSITORY built-in [environment variable](https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables) i.e jlmayorga/docker-react
